### PR TITLE
allow gnome-shell 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "Like Activities Overview but only showing windows of the currently active application",
   "name": "Applications Window Overview",
   "shell-version": [
-    "44", "43"
+    "44", "43", "42"
   ],
   "url": "https://github.com/freder/application-windows-overview",
   "uuid": "application-windows-overview@github.freder",


### PR DESCRIPTION

on `Ubuntu 22.04 LTS`
(with `GNOME Shell 42.9`)

it works